### PR TITLE
Make a better VHS-specific help command

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,6 +1,5 @@
 [
   "hubot-diagnostics",
-  "hubot-help",
   "hubot-google-images",
   "hubot-google-translate",
   "hubot-pugme",

--- a/scripts/help.coffee
+++ b/scripts/help.coffee
@@ -1,0 +1,42 @@
+# Description:
+#   Makes vhsbot a bit more helpful
+#
+# Commands:
+#   hubot help - Output a nice help message
+#   hubot list commands - Displays all of the help commands that Hubot knows about.
+#   hubot list commands <query> - Displays all help commands that match <query>.
+#
+# Notes:
+#   Pulled the 'list commands' from the hubot-help
+#
+# Author:
+#   seanhagen
+#
+
+module.exports = (robot) ->
+
+  robot.respond /help/, (res) ->
+    res.send "Hey, I'm the VHS chat bot ( aka "+res.robot.name+" )"
+    res.send "If you want to get a list of commands, pm me 'list commands' ( you can look for specific commands by using 'list commands <words>')"
+    res.send "If you want to get a look at my code, head over to http://github.com/vhs/vhsbot"
+
+  robot.respond /list commands(?:\s+(.*))?$/i, (msg) ->
+    cmds = renamedHelpCommands(robot)
+    filter = msg.match[1]
+
+    if filter
+      cmds = cmds.filter (cmd) ->
+        cmd.match new RegExp(filter, 'i')
+      if cmds.length == 0
+        msg.send "No available commands match #{filter}"
+        return
+
+    emit = cmds.join "\n"
+
+    msg.send emit
+
+renamedHelpCommands = (robot) ->
+  robot_name = robot.alias or robot.name
+  help_commands = robot.helpCommands().map (command) ->
+    command.replace /hubot/ig, robot_name
+  help_commands.sort()


### PR DESCRIPTION
For #5.

Changes 'vhsbot help' to output a small help message.

Old 'vhsbot help' now accessible through 'vhsbot list commands'.
