### PR TITLE
Packt free book at noon

### DIFF
--- a/bin/run.example
+++ b/bin/run.example
@@ -7,6 +7,7 @@ export HUBOT_TWITTER_ACCESS_TOKEN_SECRET=some-access-secret-from-twitter
 export HUBOT_SLACK_TOKEN=some-slack-token-from-well-slack
 export HUBOT_MUTE_ROOM_PREFIX="#"
 export HUBOT_PACKT_CRON='0 12 * * *' # every day at noon
+export HUBOT_PACKT_ROOM='#random' # slack '#random' room
 
 export EXPRESS_PORT=8080
 

--- a/bin/run.example
+++ b/bin/run.example
@@ -6,5 +6,8 @@ export HUBOT_TWITTER_ACCESS_TOKEN=some-access-token-from-twitter
 export HUBOT_TWITTER_ACCESS_TOKEN_SECRET=some-access-secret-from-twitter
 export HUBOT_SLACK_TOKEN=some-slack-token-from-well-slack
 export HUBOT_MUTE_ROOM_PREFIX="#"
+export HUBOT_PACKT_CRON='0 12 * * *' # every day at noon
+
+export EXPRESS_PORT=8080
 
 bin/hubot --adapter slack

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Helpful robot for VHS Slack chat.",
   "dependencies": {
     "cheerio": "^0.19.0",
+    "cron": "^1.0.9",
     "hubot": "^2.16.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.2.2",

--- a/scripts/packt-free-book.coffee
+++ b/scripts/packt-free-book.coffee
@@ -10,6 +10,7 @@
 #
 # Configuration
 #   HUBOT_PACKT_CRON
+#   HUBOT_PACKT_ROOM
 #
 # Notes:
 #   Lookit all this coffeescript!
@@ -31,7 +32,7 @@ module.exports = (robot) ->
     get_free_book msg.message.room, robot
 
   func = () =>
-    get_free_book '#random', robot
+    get_free_book process.env.HUBOT_PACKT_ROOM, robot
 
   job = new cron
     cronTime: process.env.HUBOT_PACKT_CRON

--- a/scripts/packt-free-book.coffee
+++ b/scripts/packt-free-book.coffee
@@ -15,6 +15,7 @@
 #   seanhagen
 #
 cheerio = require 'cheerio'
+cron = require('cron').CronJob
 
 free_book_url = "https://www.packtpub.com/packt/offers/free-learning"
 
@@ -25,6 +26,10 @@ module.exports = (robot) ->
 
   robot.respond /todays free book/, (msg) ->
     get_free_book msg, robot
+
+  cron '12 0 * * *', () =>
+    robot.messageRoom '#random'
+
 
 
 get_free_book = (msg, robot) =>


### PR DESCRIPTION
Making the free book of the day message a specific room at a specific time.

The room is controlled via the HUBOT_PACKT_ROOM environment variable.

The time is a cron string, configured via the HUBOT_PACKT_CRON environment variable.

The default is every day at noon, to the room '#random'.

Also refactored the `get_free_book` and `book_reply` methods so they take a room instead of the message object, and use robot.messageRoom instead of msg.reply.
